### PR TITLE
Added missing environment variables needed for docker deployment in development

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,23 @@
+# Environment Variables for 3DBioNotes
+# Variables for the MySQL/MariaDB connection
+# Adapt them to your environment
 DB_HOST=db
 DB_PORT=3306
 DB_NAME=bionotes
 DB_USER=change.me
 DB_PASSWD=change.me
+
+# Port settings for
+# 3DBioNotes Web
+APP_EXT_PORT=8000
+# PHPMyAdmin port
+PMA_EXT_PORT=8001
+
+# Variables for the docker compose files (both production and development)
+# Uncomment and add a path for each element
+#APP_BASE_PATH=""
+#APP_DATABASES_PATH=""
+#BLAST_BIN=""
+#BLAST_DATABASE=""
+#DB_EXT_DBS=""
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@
 
 Use rvm or rbenv to select the Ruby version specified in Gemfile and then run:
 
+*Note:* To install rvm on Ubuntu, follow the instructions on the [ubuntu rvm repository](https://github.com/rvm/ubuntu_rvm)
+
 ```
 $ rvm install ruby-3.3.1
 $ gem install bundler:2.5.10
@@ -53,7 +55,10 @@ $ bundle exec rails server
 ### Setup docker-compose
 
 1. Create .env file from .env.sample
-2. Start docker containers with following command
+2. Uncomment and fill the mandatory environment variables in the .env file, w: APP_BASE_PATH, APP_DATABASES_PATH, BLAST_BIN,BLAST_DATABASE and DB_EXT_DBS.
+Docker compose won't launch the containers otherwise or if they are empty. The value needed is a path to bind in your system.
+3. (Optional) Adapt the reamining environment, such as ports and database credentials
+3. Start docker containers with following command
 
 ```
 docker-compose -f docker-compose.yml -f docker-compose.development.yml up -d


### PR DESCRIPTION
When launching 3D bionotes in development in a new system for the first time, the are some environment variables missing that do not allow docker compose to build the containers nor build the modified images. . This commit changes two things:

1. Improves the .env.sample file to explicitely show those missing environment variables (APP_EXT_PORT, PMA_EXT_PORT, APP_BASE_PATH, APP_DATABASES_PATH, BLAST_BIN,BLAST_DATABASE and DB_EXT_DBS) some of which with a default value and some commented and mandatory. These variables are either the ports needed to access 3DBionotes and related web services or refer to the paths in the host system that store the data needed for the application to work. 3DBionotes has now the default port of 8000 and PHPmyAdmind port 8081. The other variables, which correspond to the paths, are mandatory to fill before starting the development setup, as the paths will change according to user preferences or system
2. This changes have been explicitely mentioned on the README file, in the "Setup development" section. This also added a note for those who have an Ubuntu installation but have yet to install ruby or ruby managers (which was my case), because this is needed to complete the setup according to the readme instructions.